### PR TITLE
add shortcuts at the save dialog for mac

### DIFF
--- a/src/js/app/ui/dialog/Save.js
+++ b/src/js/app/ui/dialog/Save.js
@@ -7,10 +7,14 @@ define([
 		var View = Backbone.View.extend({
 			el: '#save-dialog',
 
+			isMacCommandKeyPressed: false,
+
 			events: {
 				'click ._dont_save': 'dontSaveHandler',
 				'click ._save': 'saveHandler',
-				'click ._cancel': 'cancelHandler'
+				'click ._cancel': 'cancelHandler',
+				'keydown': 'keyDown',
+				'keyup': 'keyUp'
 			},
 
 			initialize: function() {
@@ -36,7 +40,34 @@ define([
 			dontSaveHandler: function() {
 				this.trigger('dont-save');
 				this.hide();
+			},
+
+			keyDown: function(e) {
+				if (/Mac/.test(navigator.platform)) {
+					// keyCode 91 and 93 are MacOS Left and Right Command Keys.
+					if ((e.keyCode === 91 || e.keyCode === 93)) {
+						this.$isMacCommandKeyPressed = true;
+
+					} else if (this.$isMacCommandKeyPressed && e.keyCode === 68) {
+						this.dontSaveHandler();
+
+					} else if (e.keyCode === 13) {
+						this.saveHandler();
+
+					} else if (e.keyCode === 27) {
+						this.cancelHandler();
+					}
+				}
+			},
+
+			keyUp: function(e) {
+				if (/Mac/.test(navigator.platform)) {
+					if ((e.keyCode === 91 || e.keyCode === 93)) {
+						this.$isMacCommandKeyPressed = false;
+					}
+				}
 			}
+
 		});
 
 		return View;


### PR DESCRIPTION
As we discussed at [here](http://haroopad.userecho.com/topic/248042-mac-commandd/), there are various ways to deal with shortcuts in a dialog box for MacOS. This request is one of the approaches.
- Command+D - Don't Save
- Enter Key - Always Save
- Escape Key - Always Cancel

And actually I'm a big fan of haroopad, thank to @rhiokim and the team, you guys are doing awesome, kudos!
